### PR TITLE
Add Windows compatibility header

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -7,7 +7,7 @@ include Makefile
 override CC      := gcc
 override LINK    := $(CC)
 override PKG_CONFIG := pkg-config
-override CFLAGS  += -mms-bitfields
+override CFLAGS  += -mms-bitfields -include WINDOWS/win_compat.h
 override LDFLAGS += -mwindows
 override SYSLIBS := -lwinpthread
 

--- a/WINDOWS/win_compat.h
+++ b/WINDOWS/win_compat.h
@@ -1,0 +1,8 @@
+#ifndef WIN_COMPAT_H
+#define WIN_COMPAT_H
+
+#ifndef SO_REUSEPORT
+#define SO_REUSEPORT SO_REUSEADDR
+#endif
+
+#endif // WIN_COMPAT_H


### PR DESCRIPTION
## Summary
- define `SO_REUSEPORT` fallback for MinGW builds
- automatically include this header in the Windows Makefile

## Testing
- `make -f Makefile.win` *(fails: pulse/pulseaudio.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_68526150376c8326a3b845d462990bdd