### PR TITLE
Add win compatibility for network headers

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -7,7 +7,7 @@ include Makefile
 override CC      := gcc
 override LINK    := $(CC)
 override PKG_CONFIG := pkg-config
-override CFLAGS  += -mms-bitfields
+override CFLAGS  += -mms-bitfields -include WINDOWS/win_compat.h
 override LDFLAGS += -mwindows
 override SYSLIBS := -lwinpthread
 

--- a/WINDOWS/win_compat.h
+++ b/WINDOWS/win_compat.h
@@ -1,0 +1,19 @@
+#ifndef WIN_COMPAT_H
+#define WIN_COMPAT_H
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#ifndef socklen_t
+typedef int socklen_t;
+#endif
+#ifndef close
+#define close closesocket
+#endif
+#endif
+
+#ifndef SO_REUSEPORT
+#define SO_REUSEPORT SO_REUSEADDR
+#endif
+
+#endif // WIN_COMPAT_H

--- a/src/about_menu.c
+++ b/src/about_menu.c
@@ -23,8 +23,12 @@
 #include <string.h>
 #include <stdlib.h>
 #include <sys/socket.h>
+#ifndef _WIN32
 #include <netinet/in.h>
+#endif
+#ifndef _WIN32
 #include <arpa/inet.h>
+#endif
 #include <wdsp.h>             // only needed for GetWDSPVersion
 
 #include "about_menu.h"

--- a/src/bootldrsim.c
+++ b/src/bootldrsim.c
@@ -46,8 +46,12 @@
 #include <pcap.h>
 #include <errno.h>
 #include <sys/socket.h>
+#ifndef _WIN32
 #include <netinet/in.h>
+#endif
+#ifndef _WIN32
 #include <arpa/inet.h>
+#endif
 #include <netinet/if_ether.h>
 #include <fcntl.h>
 #include <net/if_dl.h>

--- a/src/bootloader.c
+++ b/src/bootloader.c
@@ -78,15 +78,21 @@
 #include <pcap.h>
 #include <errno.h>
 #include <sys/socket.h>
+#ifndef _WIN32
 #include <netinet/in.h>
+#endif
+#ifndef _WIN32
 #include <arpa/inet.h>
+#endif
 #include <netinet/if_ether.h>
 #include <fcntl.h>
 #ifdef __APPLE__
   #include <net/if_dl.h>
 #else
   #include <sys/ioctl.h>
-  #include <net/if.h>
+  #ifndef _WIN32
+#include <net/if.h>
+#endif
 #endif
 #include <string.h>
 

--- a/src/client_server.c
+++ b/src/client_server.c
@@ -56,10 +56,16 @@
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/socket.h>
+#ifndef _WIN32
 #include <netinet/in.h>
+#endif
 #include <netinet/ip.h>
+#ifndef _WIN32
 #include <net/if.h>
+#endif
+#ifndef _WIN32
 #include <arpa/inet.h>
+#endif
 #include <netdb.h>
 #include <string.h>
 #include <strings.h>

--- a/src/client_server.h
+++ b/src/client_server.h
@@ -22,7 +22,9 @@
 
 #include <gtk/gtk.h>
 #include <stdint.h>
+#ifndef _WIN32
 #include <netinet/in.h>
+#endif
 
 #include "mode.h"
 #include "receiver.h"

--- a/src/configure.c
+++ b/src/configure.c
@@ -26,8 +26,12 @@
 #include <string.h>
 #include <semaphore.h>
 #include <sys/socket.h>
+#ifndef _WIN32
 #include <netinet/in.h>
+#endif
+#ifndef _WIN32
 #include <arpa/inet.h>
+#endif
 
 #include "actions.h"
 #include "channel.h"

--- a/src/discovered.h
+++ b/src/discovered.h
@@ -20,7 +20,9 @@
 #ifndef _DISCOVERED_H_
 #define _DISCOVERED_H_
 
+#ifndef _WIN32
 #include <netinet/in.h>
+#endif
 
 #define MAX_DEVICES 16
 

--- a/src/discovery.c
+++ b/src/discovery.c
@@ -25,8 +25,12 @@
 #include <string.h>
 #include <semaphore.h>
 #include <sys/socket.h>
+#ifndef _WIN32
 #include <netinet/in.h>
+#endif
+#ifndef _WIN32
 #include <arpa/inet.h>
+#endif
 #include <sys/stat.h>
 
 #include "actions.h"

--- a/src/hpsdrsim.c
+++ b/src/hpsdrsim.c
@@ -74,9 +74,13 @@
 #include <sys/time.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
+#ifndef _WIN32
 #include <netinet/in.h>
+#endif
 #include <netinet/tcp.h>
+#ifndef _WIN32
 #include <arpa/inet.h>
+#endif
 #ifdef __APPLE__
   #include "MacOS.h"  // emulate clock_gettime on old MacOS systems
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -27,8 +27,12 @@
 #include <sys/types.h>
 #include <sys/resource.h>
 #include <sys/utsname.h>
+#ifndef _WIN32
 #include <netinet/in.h>
+#endif
+#ifndef _WIN32
 #include <arpa/inet.h>
+#endif
 
 #include <wdsp.h>    // only needed for WDSPwisdom() and wisdom_get_status()
 

--- a/src/new_discovery.c
+++ b/src/new_discovery.c
@@ -23,13 +23,25 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/ioctl.h>
+#ifndef _WIN32
 #include <netinet/in.h>
+#endif
+#ifndef _WIN32
 #include <arpa/inet.h>
+#endif
 #include <netdb.h>
+#ifndef _WIN32
 #include <net/if_arp.h>
+#endif
+#ifndef _WIN32
 #include <net/if.h>
+#endif
+#ifndef _WIN32
 #include <netinet/in.h>
+#endif
+#ifndef _WIN32
 #include <ifaddrs.h>
+#endif
 #include <string.h>
 #include <errno.h>
 

--- a/src/new_protocol.c
+++ b/src/new_protocol.c
@@ -28,13 +28,23 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/ioctl.h>
+#ifndef _WIN32
 #include <netinet/in.h>
+#endif
+#ifndef _WIN32
 #include <arpa/inet.h>
+#endif
 #include <netdb.h>
+#ifndef _WIN32
 #include <net/if_arp.h>
+#endif
+#ifndef _WIN32
 #include <net/if.h>
+#endif
 #include <netinet/ip.h>
+#ifndef _WIN32
 #include <ifaddrs.h>
+#endif
 #include <semaphore.h>
 #include <math.h>
 #include <sys/select.h>

--- a/src/newhpsdrsim.c
+++ b/src/newhpsdrsim.c
@@ -35,9 +35,13 @@
 #include <sys/socket.h>
 #include <errno.h>
 #include <string.h>
+#ifndef _WIN32
 #include <netinet/in.h>
+#endif
 #include <unistd.h>
+#ifndef _WIN32
 #include <arpa/inet.h>
+#endif
 #include <math.h>
 #ifdef __APPLE__
   #include "MacOS.h"  // emulate clock_gettime on old MacOS systems

--- a/src/old_discovery.c
+++ b/src/old_discovery.c
@@ -23,12 +23,22 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/ioctl.h>
+#ifndef _WIN32
 #include <netinet/in.h>
+#endif
+#ifndef _WIN32
 #include <arpa/inet.h>
+#endif
 #include <netdb.h>
+#ifndef _WIN32
 #include <net/if_arp.h>
+#endif
+#ifndef _WIN32
 #include <net/if.h>
+#endif
+#ifndef _WIN32
 #include <ifaddrs.h>
+#endif
 #include <string.h>
 #include <errno.h>
 #include <fcntl.h>

--- a/src/old_protocol.c
+++ b/src/old_protocol.c
@@ -24,13 +24,23 @@
 #include <sys/socket.h>
 #include <sys/ioctl.h>
 #include <sys/time.h>
+#ifndef _WIN32
 #include <netinet/in.h>
+#endif
+#ifndef _WIN32
 #include <arpa/inet.h>
+#endif
 #include <netdb.h>
+#ifndef _WIN32
 #include <net/if_arp.h>
+#endif
+#ifndef _WIN32
 #include <net/if.h>
+#endif
 #include <netinet/ip.h>
+#ifndef _WIN32
 #include <ifaddrs.h>
+#endif
 #include <semaphore.h>
 #include <string.h>
 #include <errno.h>

--- a/src/protocols.c
+++ b/src/protocols.c
@@ -25,8 +25,12 @@
 #include <string.h>
 #include <semaphore.h>
 #include <sys/socket.h>
+#ifndef _WIN32
 #include <netinet/in.h>
+#endif
+#ifndef _WIN32
 #include <arpa/inet.h>
+#endif
 
 #include "property.h"
 #include "protocols.h"

--- a/src/radio.c
+++ b/src/radio.c
@@ -26,8 +26,12 @@
 #include <sys/time.h>
 #include <sys/types.h>
 #include <sys/socket.h>
+#ifndef _WIN32
 #include <netinet/in.h>
+#endif
+#ifndef _WIN32
 #include <arpa/inet.h>
+#endif
 #include <netdb.h>
 #include <termios.h>
 

--- a/src/rigctl.c
+++ b/src/rigctl.c
@@ -35,7 +35,9 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <sys/socket.h>
-#include <arpa/inet.h> //inet_addr
+#ifndef _WIN32
+#include <arpa/inet.h>
+#endif //inet_addr
 #include <netinet/tcp.h>
 
 #include "actions.h"

--- a/src/rx_panadapter.c
+++ b/src/rx_panadapter.c
@@ -24,7 +24,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <semaphore.h>
+#ifndef _WIN32
 #include <arpa/inet.h>
+#endif
 
 #include "actions.h"
 #include "agc.h"

--- a/src/saturnmain.c
+++ b/src/saturnmain.c
@@ -46,9 +46,15 @@
 #include <sys/time.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
+#ifndef _WIN32
 #include <netinet/in.h>
+#endif
+#ifndef _WIN32
 #include <arpa/inet.h>
+#endif
+#ifndef _WIN32
 #include <net/if.h>
+#endif
 #include <semaphore.h>
 #include <sys/stat.h>
 

--- a/src/saturnserver.c
+++ b/src/saturnserver.c
@@ -48,9 +48,15 @@
 #include <sys/time.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
+#ifndef _WIN32
 #include <netinet/in.h>
+#endif
+#ifndef _WIN32
 #include <arpa/inet.h>
+#endif
+#ifndef _WIN32
 #include <net/if.h>
+#endif
 #include <semaphore.h>
 
 #include "message.h"

--- a/src/saturnserver.h
+++ b/src/saturnserver.h
@@ -35,7 +35,9 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#ifndef _WIN32
 #include <netinet/in.h>
+#endif
 
 // START threaddata.h
 //

--- a/src/stemlab_discovery.c
+++ b/src/stemlab_discovery.c
@@ -25,8 +25,12 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <sys/socket.h>
+#ifndef _WIN32
 #include <net/if.h>
+#endif
+#ifndef _WIN32
 #include <arpa/inet.h>
+#endif
 #include <string.h>
 #include <unistd.h>
 #include <curl/curl.h>

--- a/src/tci.c
+++ b/src/tci.c
@@ -25,7 +25,9 @@
 #include <gdk/gdk.h>
 
 #include <sys/socket.h>
+#ifndef _WIN32
 #include <arpa/inet.h>
+#endif
 #include <netinet/tcp.h>
 #include <ctype.h>
 

--- a/src/tts.c
+++ b/src/tts.c
@@ -51,7 +51,9 @@
 #include <unistd.h>
 #include <string.h>
 #include <sys/socket.h>
+#ifndef _WIN32
 #include <netinet/in.h>
+#endif
 
 #include "message.h"
 #include "radio.h"

--- a/src/udplistener.c
+++ b/src/udplistener.c
@@ -49,7 +49,9 @@
 #include <stdio.h>
 #include <fcntl.h>
 #include <sys/socket.h>
+#ifndef _WIN32
 #include <netinet/in.h>
+#endif
 
 int main() {
   int optval;

--- a/src/udpsender.c
+++ b/src/udpsender.c
@@ -26,7 +26,9 @@
 #include <unistd.h>
 #include <string.h>
 #include <sys/socket.h>
+#ifndef _WIN32
 #include <netinet/in.h>
+#endif
 
 //
 // tts_send: send broadcast UDP packet containing a string

--- a/src/vfo.c
+++ b/src/vfo.c
@@ -24,12 +24,22 @@
 #include <string.h>
 #include <stdlib.h>
 #include <unistd.h>
+#ifndef _WIN32
 #include <netinet/in.h>
+#endif
+#ifndef _WIN32
 #include <arpa/inet.h>
+#endif
 #include <netdb.h>
+#ifndef _WIN32
 #include <net/if_arp.h>
+#endif
+#ifndef _WIN32
 #include <net/if.h>
+#endif
+#ifndef _WIN32
 #include <ifaddrs.h>
+#endif
 
 #include "appearance.h"
 #include "discovered.h"


### PR DESCRIPTION
## Summary
- provide Windows winsock fallback in `win_compat.h`
- wrap Linux-only network headers in `#ifndef _WIN32`

## Testing
- `make -f Makefile.win` *(fails: pulse/pulseaudio.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_68526150376c8326a3b845d462990bdd