### PR TITLE
Fix build warnings for Win

### DIFF
--- a/src/actions.c
+++ b/src/actions.c
@@ -19,6 +19,7 @@
 
 #include <gtk/gtk.h>
 #include <math.h>
+#include <unistd.h>
 
 #include "actions.h"
 #include "agc.h"

--- a/src/client_server.c
+++ b/src/client_server.c
@@ -69,6 +69,7 @@
 #include <netdb.h>
 #include <string.h>
 #include <strings.h>
+#include <unistd.h>
 #ifndef __APPLE__
   #include <endian.h>
 #endif

--- a/src/exit_menu.c
+++ b/src/exit_menu.c
@@ -21,6 +21,7 @@
 #include <semaphore.h>
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
 
 #include "actions.h"
 #include "discovery.h"

--- a/src/main.c
+++ b/src/main.c
@@ -20,6 +20,7 @@
 #include <gdk/gdk.h>
 #include <math.h>
 #include <unistd.h>
+#include <pthread.h>
 #include <stdlib.h>
 #include <string.h>
 #include <semaphore.h>

--- a/src/new_discovery.c
+++ b/src/new_discovery.c
@@ -44,6 +44,7 @@
 #endif
 #include <string.h>
 #include <errno.h>
+#include <unistd.h>
 
 #include "discovered.h"
 #include "discovery.h"

--- a/src/old_discovery.c
+++ b/src/old_discovery.c
@@ -41,6 +41,7 @@
 #endif
 #include <string.h>
 #include <errno.h>
+#include <unistd.h>
 #include <fcntl.h>
 #include <sys/select.h>
 

--- a/src/old_protocol.c
+++ b/src/old_protocol.c
@@ -41,6 +41,8 @@
 #ifndef _WIN32
 #include <ifaddrs.h>
 #endif
+#include <unistd.h>
+#include <pthread.h>
 #include <semaphore.h>
 #include <string.h>
 #include <errno.h>


### PR DESCRIPTION
## Summary
- include `<unistd.h>` to avoid implicit function warnings
- include `<pthread.h>` where missing

## Testing
- `make -f Makefile.win` *(fails: `pulse/pulseaudio.h: No such file or directory`)*
- `make AUDIO=PORTAUDIO -f Makefile.win` *(fails: `portaudio.h: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_685288ccf3f883268df48031ef73c591